### PR TITLE
tt_aftercore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+# This is a workflow to perform basic verification for KoLmafia ASH scripts
+
+name: CI
+env:
+  SCRIPT_NAMES: "blackpudding.ash dpills.ash getmu.ash greygoo.ash guzzlr.ash plevel.ash tt_aftercore.ash tt_display.ash tt_fortune.ash tt_kingliberated.ash tt_login.ash tt_logout.ash tt_preascension.ash tt_quickconfig.ash"
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Java JDK
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+
+    - name: Determine KoLmafia version
+      id: mafia
+      run: |
+        set -o pipefail
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '.lastCompletedBuild.changeSet.items[0].revision')
+        if [[ -z "$MAFIA_BUILD" ]]; then
+          echo "Could not determine mafia version of Jenkins last completed build!"
+          exit 1
+        fi
+        export JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/lastCompletedBuild/artifact/dist/KoLmafia-${MAFIA_BUILD}.jar"
+        echo "::set-output name=jenkins::$JENKINS_URL"
+        echo "Jenkins URL = ${JENKINS_URL}"
+        echo "::set-output name=build::$MAFIA_BUILD"
+        echo "Jenkins Mafia Build = ${MAFIA_BUILD}"
+
+    - name: Cache KoLmafia
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: .github/kolmafia.jar
+        key: kolmafia-${{steps.mafia.outputs.build}}
+
+    - name: Download KoLmafia
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        curl "${{steps.mafia.outputs.jenkins}}" --output .github/kolmafia.jar
+
+    - name: Install and verify
+      run: |
+        cd RELEASE
+
+        if [[ -f "dependencies.txt" ]]; then
+          # Install dependencies
+          echo "Installing dependencies..."
+
+          output_file="scripts/_ci_dependencies.ash"
+          while read -r line || [ -n "$line" ]; do
+            echo "cli_execute('svn checkout ${line}');" >> "$output_file"
+          done < "dependencies.txt"
+          echo "cli_execute('exit');" >> "$output_file"
+          java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_dependencies
+        fi
+
+        errors=0
+        for ashfile in ${SCRIPT_NAMES}; do
+            # Run the verification
+            echo "Verifying ${ashfile}..."
+
+            echo "try { cli_execute('verify ${ashfile}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+            output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
+            if [[ $output == *"Script verification complete." ]]; then
+                echo "Verified ${ashfile}!"
+            else
+                echo $output
+                errors=$((errors+1))
+            fi
+        done
+
+        exit ${errors}

--- a/BUILD/settings/tt_aftercore.dat
+++ b/BUILD/settings/tt_aftercore.dat
@@ -1,0 +1,8 @@
+tt_aftercore_fatLootToken	boolean	Farm fat loot tokens if you still need more to buy the skills and familiars
+tt_aftercore_iceHouseAMC	boolean	Automatically capture AMC gremlin in the ice house
+tt_aftercore_guildUnlock	boolean	Unlock your guild
+tt_aftercore_meatFarm	boolean	Farm some meat. Currently terrible at it.
+tt_aftercore_useAstralLeftovers	boolean	Use leftover astral drink/food
+tt_aftercore_buyStuff	boolean	Allow buying some useful things
+tt_aftercore_eatSurpriseEggs	boolean	Automatically fill stomach with [lucky surprise egg] and [spooky surprise egg]
+tt_aftercore_consumeAll	boolean	Run soolar CONSUME script with ALL command after all other eating is done

--- a/RELEASE/data/tt_settings.txt
+++ b/RELEASE/data/tt_settings.txt
@@ -13,6 +13,15 @@ greygoo	6	greygoo_fightGoo	boolean	fight the goo monsters
 
 plevel	0	plevel_mpa	int	meat per adventure value. input how much each adventure is worth to you if you were farming meat. this will be used to calculate whether it is worth it or not to buy a potion.
 
+tt_aftercore	0	tt_aftercore_fatLootToken	boolean	Farm fat loot tokens if you still need more to buy the skills and familiars
+tt_aftercore	1	tt_aftercore_iceHouseAMC	boolean	Automatically capture AMC gremlin in the ice house
+tt_aftercore	2	tt_aftercore_guildUnlock	boolean	Unlock your guild
+tt_aftercore	3	tt_aftercore_meatFarm	boolean	Farm some meat. Currently terrible at it.
+tt_aftercore	4	tt_aftercore_useAstralLeftovers	boolean	Use leftover astral drink/food
+tt_aftercore	5	tt_aftercore_buyStuff	boolean	Allow buying some useful things
+tt_aftercore	6	tt_aftercore_eatSurpriseEggs	boolean	Automatically fill stomach with [lucky surprise egg] and [spooky surprise egg]
+tt_aftercore	7	tt_aftercore_consumeAll	boolean	Run soolar CONSUME script with ALL command after all other eating is done
+
 tt_login	0	tt_login_pvp	boolean	break hippy stone to unlock pvp
 tt_login	1	tt_login_chocolateEat	boolean	when login with unlimited mall access eat chocolates
 tt_login	2	tt_login_chocolateMaxPricePerAdv	int	maximum price per adventure for chocolates

--- a/RELEASE/relay/relay_ttpack.ash
+++ b/RELEASE/relay/relay_ttpack.ash
@@ -39,10 +39,11 @@ void handleSetting(string type, int x)
 	string color = "white";
 	switch(type)
 	{
-	case "tt_login":	color = "#8BDCE7";		break;
-	case "greygoo":		color = "#6FE26F";		break;
-	case "plevel":		color = "#8BDCE7";		break;
-	default:			color = "#ffffff";		break;
+	case "greygoo":			color = "#6FE26F";		break;
+	case "plevel":			color = "#8BDCE7";		break;
+	case "tt_aftercore":	color = "#6FE26F";		break;
+	case "tt_login":		color = "#8BDCE7";		break;
+	default:				color = "#ffffff";		break;
 	}
 
 	setting set = s[type][x];
@@ -105,9 +106,10 @@ void write_settings_key()
 {
 	//display the key to the settings table.
 	writeln("<table><tr><th>Settings Color Codings</th></tr>");
-	writeln("<tr bgcolor=#8BDCE7><td>tt_login.ash script to automate some post login actions</td></tr>");
 	writeln("<tr bgcolor=#6FE26F><td>greygoo.ash script to automate greygoo ascensions</td></tr>");
 	writeln("<tr bgcolor=#8BDCE7><td>plevel.ash script to automate some powerleveling in aftercore</td></tr>");
+	writeln("<tr bgcolor=#6FE26F><td>tt_aftercore.ash script to automate aftercore actions</td></tr>");
+	writeln("<tr bgcolor=#8BDCE7><td>tt_login.ash script to automate some post login actions</td></tr>");
 	writeln("</table>");
 }
 
@@ -161,10 +163,6 @@ void main()
 
 	writeln("<form action='' method='post'>");
 	writeln("<table><tr><th width=20%>Setting</th><th width=20%>Value</th><th width=60%>Description</th></tr>");
-	foreach x in s["tt_login"]
-	{
-		handleSetting("tt_login", x);
-	}
 	foreach x in s["greygoo"]
 	{
 		handleSetting("greygoo", x);
@@ -172,6 +170,14 @@ void main()
 	foreach x in s["plevel"]
 	{
 		handleSetting("plevel", x);
+	}
+	foreach x in s["tt_aftercore"]
+	{
+		handleSetting("tt_login", x);
+	}
+	foreach x in s["tt_login"]
+	{
+		handleSetting("tt_login", x);
 	}
 	writeln("<tr><td align=center colspan='3'><input type='submit' name='' value='Save Changes'/></td></tr></table></form>");
 

--- a/RELEASE/scripts/ttpack/greygoo.ash
+++ b/RELEASE/scripts/ttpack/greygoo.ash
@@ -377,12 +377,8 @@ boolean greygoo_doTasks()
 	greygoo_consume();
 	councilMaintenance();
 	cli_execute("refresh quests");		//greygoo has broken tracking verified for: questL02Larva && questM19Hippy
+	if(out_of_adv()) return false;
 	
-	if(my_adventures() == 0)
-	{
-		print("out of adventures");
-		return false;
-	}
 	if(my_familiar() == $familiar[Stooper])
 	{
 		auto_log_info("Avoiding stooper stupor...", "blue");

--- a/RELEASE/scripts/ttpack/tt_aftercore.ash
+++ b/RELEASE/scripts/ttpack/tt_aftercore.ash
@@ -263,16 +263,10 @@ boolean tt_meatFarm(boolean override)
 boolean tt_doTasks()
 {
 	//main loop of tt_aftercore. returning true resets the loop. returning false exits the loop
-	
-	if(my_adventures() == 0)
-	{
-		print("Out of adventures", "red");
-		return false;
-	}
-	
-	resetState();
 	auto_interruptCheck();
+	resetState();
 	tt_chooseFamiliar();
+	if(out_of_adv()) return false;
 	
 	if(tt_acquireFamiliars()) return true;
 	if(tt_iceHouseAMC(false)) return true;
@@ -285,19 +279,12 @@ boolean tt_doTasks()
 boolean tt_doSingleTask(string command)
 {
 	//this is a primary loop. returning true resets the loop. returning false exits the loop
-	
-	if(!auto_unreservedAdvRemaining())
-	{
-		print("Not enough reserved adventures. Done for today", "red");
-		return false;
-	}
-	
+	auto_interruptCheck();
 	resetState();
-	auto_interruptCheck();	
 	tt_chooseFamiliar();
+	if(out_of_adv()) return false;
 	
 	if(tt_acquireFamiliars()) return true;
-	
 	if(command == "amc")
 	{
 		return tt_iceHouseAMC(true);
@@ -368,6 +355,10 @@ void main(string command)
 	backupSetting("currentMood", "apathetic");
 	backupSetting("logPreferenceChange", "true");
 	backupSetting("logPreferenceChangeFilter", "maximizerMRUList,testudinalTeachings,auto_maximize_current");
+	
+	initializeDay(my_daycount());
+	horseDark();
+	auto_voteSetup();
 	
 	tt_useAstralLeftovers();
 	tt_eatSurpriseEggs();

--- a/RELEASE/scripts/ttpack/tt_aftercore.ash
+++ b/RELEASE/scripts/ttpack/tt_aftercore.ash
@@ -8,26 +8,6 @@ boolean tt_fatLootToken();
 boolean tt_meatFarm();
 void tt_help();
 
-void tt_aftercore_settings_print()
-{
-	//print current settings status
-	print();
-	print("Current settings for tt_aftercore:", "blue");
-	tt_printSetting("tt_aftercore_fatLootToken", "Farm fat loot tokens if you still need more to buy the skills and familiars");
-	tt_printSetting("tt_aftercore_iceHouseAMC", "Automatically capture AMC gremlin in the ice house");
-	tt_printSetting("tt_aftercore_guildUnlock", "Unlock your guild");
-	tt_printSetting("tt_aftercore_meatFarm", "Farm some meat. Currently terrible at it.");
-	tt_printSetting("tt_aftercore_useAstralLeftovers", "Use leftover astral drink/food");
-	tt_printSetting("tt_aftercore_buyStuff", "Allow buying some useful things");
-	tt_printSetting("tt_aftercore_eatSurpriseEggs", "Automatically fill stomach with [lucky surprise egg] and [spooky surprise egg]");
-	tt_printSetting("tt_aftercore_consumeAll", "Run soolar CONSUME script with ALL command after all other eating is done");
-	
-	print();
-	print("You can make changes to these settings by typing:", "blue");
-	print("set [setting_name] = [target]", "blue");
-	print();
-}
-
 void tt_chooseFamiliar()
 {
 	familiar familiar_target_100 = get_property("auto_100familiar").to_familiar();
@@ -343,13 +323,12 @@ void tt_help()
 	print("To use type in gCLI:");
 	print("tt_aftercore [goal]");
 	print("Currently supported options for [goal]:");
-	print("help = display available commands");
-	print("config = display configuration");
 	print("auto = automatically does all the things based on your configuration");
 	print("guild = unlock your guild");
 	print("token = gets a single fat loot token if possible");
 	print("amc = traps an AMC gremlin in the ice house. currently unimplemented");
 	print("meat = meatfarms. currently terrible at it");
+	print("anything else = show this menu");
 }
 
 void main(string command)

--- a/RELEASE/scripts/ttpack/tt_aftercore.ash
+++ b/RELEASE/scripts/ttpack/tt_aftercore.ash
@@ -1,7 +1,6 @@
 import <scripts/ttpack/util/tt_util.ash>
 
 //public prototypes
-void tt_settings_print();
 void tt_chooseFamiliar();
 boolean tt_iceHouseAMC();
 boolean tt_convert_hatchling_into_familiar(item hatchling, familiar adult);
@@ -11,62 +10,7 @@ boolean tt_fatLootToken();
 boolean tt_meatFarm();
 void tt_help();
 
-void tt_settings_defaults()
-{
-	tt_depreciate();
-	boolean new_setting_added = false;
-	
-	//set defaults
-	if(get_property("tt_aftercore_fatLootToken") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_fatLootToken", true);
-	}
-	if(get_property("tt_aftercore_iceHouseAMC") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_iceHouseAMC", true);
-	}
-	if(get_property("tt_aftercore_guildUnlock") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_guildUnlock", false);
-	}
-	if(get_property("tt_aftercore_meatFarm") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_meatFarm", false);
-	}
-	if(get_property("tt_aftercore_useAstralLeftovers") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_useAstralLeftovers", true);
-	}
-	if(get_property("tt_aftercore_buyStuff") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_buyStuff", true);
-	}
-	if(get_property("tt_aftercore_eatSurpriseEggs") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_eatSurpriseEggs", false);
-	}
-	if(get_property("tt_aftercore_consumeAll") == "")
-	{
-		new_setting_added = true;
-		set_property("tt_aftercore_consumeAll", false);
-	}
-	
-	if(new_setting_added)
-	{
-		tt_help();
-		tt_settings_print();
-		abort("Settings have been configured to default. Please verify they are correct before running me again");
-	}
-}
-
-void tt_settings_print()
+void tt_aftercore_settings_print()
 {
 	//print current settings status
 	print();
@@ -525,7 +469,7 @@ void main(string command)
 	}
 	command = to_lower_case(command);
 	
-	tt_settings_defaults();
+	tt_initialize();
 	
 	backupSetting("printStackOnAbort", true);
 	backupSetting("promptAboutCrafting", 0);
@@ -550,13 +494,9 @@ void main(string command)
 	tt_eatSurpriseEggs();
 	tt_consumeAll();
 	
-	if(command == "help" || command == "" || command == "0");
+	if(command == "help" || command == "" || command == "0" || command == "config");
 	{
 		tt_help();
-	}
-	if(command == "config")
-	{
-		tt_settings_print();
 	}
 	if(command == "auto")
 	{
@@ -568,7 +508,6 @@ void main(string command)
 		finally
 		{
 			restoreAllSettings();
-			tt_settings_print();
 		}
 	}
 	if($strings[guild, token, amc, meat] contains command)
@@ -581,7 +520,6 @@ void main(string command)
 		finally
 		{
 			restoreAllSettings();
-			tt_settings_print();
 		}
 	}
 }

--- a/RELEASE/scripts/ttpack/tt_aftercore.ash
+++ b/RELEASE/scripts/ttpack/tt_aftercore.ash
@@ -3,8 +3,6 @@ import <scripts/ttpack/util/tt_util.ash>
 //public prototypes
 void tt_chooseFamiliar();
 boolean tt_iceHouseAMC();
-boolean tt_convert_hatchling_into_familiar(item hatchling, familiar adult);
-void tt_acquireFamiliars();
 boolean tt_dailyDungeon();
 boolean tt_fatLootToken();
 boolean tt_meatFarm();
@@ -32,8 +30,6 @@ void tt_aftercore_settings_print()
 
 void tt_chooseFamiliar()
 {
-	tt_acquireFamiliars();	//get familiars.
-	
 	familiar familiar_target_100 = get_property("auto_100familiar").to_familiar();
 	if(familiar_target_100 != $familiar[none])		//do not break 100 familiar runs. yes, even in aftercore.
 	{
@@ -92,149 +88,31 @@ void tt_buyStuff()
 	tt_acquire($item[mafia thumb ring]);
 }
 
-boolean tt_convert_hatchling_into_familiar(item hatchling, familiar adult)
+boolean tt_acquireFamiliars()
 {
-	//This functions converts an item named hatchling into a familiar named adult.
-	
-	//TODO return false if no terrarium installed in camp
-	
-	if(have_familiar(adult))
-	{
-		return true;
-	}
-	if(item_amount(hatchling) == 0)
+	getTerrarium();
+	if(!checkTerrarium())
 	{
 		return false;
 	}
 	
-	print("Trying to acquire familiar [" + adult + "]", "blue");
-	visit_url("inv_familiar.php?pwd=&which=3&whichitem=" + hatchling.to_int());
-	
-	if(have_familiar(adult))
-	{
-		print("Successfully acquired familiar [" + adult + "]", "blue");
-		return true;
-	}
-	print("Failed to convert the familiar hatchling [" + hatchling + "] into the familiar [" + adult + "]", "red");
-	return false;
-}
+	hatchList();				//hatch common familiars whose hatchlings drop naturally.
+	acquireFamiliars();			//acquire common familiars then hatch them.
+	acquireFamiliarsCasual();	//acquire more common familiars then hatch them.
 
-void tt_acquireFamiliars()
-{
-	//TODO auto acquire terrarium
-
-	//Very cheap IOTM derivative that is very useful. providing MP/HP regen, and your main source of early food.
-	if(!have_familiar($familiar[Lil\' Barrel Mimic]))
-	{
-		tt_acquire($item[tiny barrel]);
-	}
-	tt_convert_hatchling_into_familiar($item[tiny barrel], $familiar[Lil\' Barrel Mimic]);
-
-	//Gelatinous Cubeling familiar costs 27 fat loot tokens and significantly improves doing daily dungeon in run.
-	//we only want to buy it from vending machine. do not spend meat on it in mall
-	if(!have_familiar($familiar[Gelatinous Cubeling]) && item_amount($item[dried gelatinous cube]) < 1 && item_amount($item[fat loot token]) > 26)
-	{
-		buy($coinmaster[Vending Machine], 1, $item[dried gelatinous cube]);
-	}
-	tt_convert_hatchling_into_familiar($item[dried gelatinous cube], $familiar[Gelatinous Cubeling]);
+	if(LX_acquireFamiliarLeprechaun()) return true;
 	
-	//Levitating Potato blocks enemy attacks and is very cheap.
-	//no point in mallbuying it despite the low price. since early on you are limited in meat availability.
-	if(!have_familiar($familiar[Levitating Potato]) && item_amount($item[potato sprout]) < 1 && item_amount($item[fat loot token]) > 0)
-	{
-		buy($coinmaster[Vending Machine], 1, $item[potato sprout]);
-	}
-	tt_convert_hatchling_into_familiar($item[potato sprout], $familiar[Levitating Potato]);
-	
-	//If you don't already have leprechaun you are a new account so poor that it is worth spending ~2 full to save ~18k meat
-	while(!have_familiar($familiar[Leprechaun]) && item_amount($item[leprechaun hatchling]) < 1 && fullness_left() > 0 && retrieve_item(1, $item[bowl of lucky charms]))
-	{
-		eat(1, $item[bowl of lucky charms]);
-	}
-	tt_convert_hatchling_into_familiar($item[leprechaun hatchling], $familiar[Leprechaun]);
-	
+	//rugamuffing imp currently disabled until I add it with a user toggleable setting to autoscend.
+	/*
 	//attack familiar that is very easy to get.
 	if(!have_familiar($familiar[Ragamuffin Imp]) && !get_property("demonSummoned").to_boolean() && item_amount($item[pile of smoking rags]) < 1 && display_amount($item[pile of smoking rags]) < 1)
 	{
 		cli_execute("summon Tatter");
 	}
-	tt_convert_hatchling_into_familiar($item[pile of smoking rags], $familiar[Ragamuffin Imp]);
+	hatchFamiliar($familiar[Ragamuffin Imp]);
+	*/
 	
-	//easy attack familiar
-	if(!have_familiar($familiar[Howling Balloon Monkey]))
-	{
-		retrieve_item(1, $item[balloon monkey]);
-	}
-	tt_convert_hatchling_into_familiar($item[balloon monkey], $familiar[Howling Balloon Monkey]);
-	
-	//delevel enemy cheaply
-	if(!have_familiar($familiar[barrrnacle]))
-	{
-		retrieve_item(1, $item[Barrrnacle]);
-	}
-	tt_convert_hatchling_into_familiar($item[barrrnacle], $familiar[Barrrnacle]);
-	
-	//stat gains cheaply. nonscaling. better at low levels
-	if(!have_familiar($familiar[Blood-Faced Volleyball]))
-	{
-		retrieve_item(1, $item[blood-faced volleyball]);
-	}
-	tt_convert_hatchling_into_familiar($item[blood-faced volleyball], $familiar[Blood-Faced Volleyball]);
-	
-	//stat gains cheaply. scaling. better at high levels
-	if(!have_familiar($familiar[hovering sombrero]))
-	{
-		retrieve_item(1, $item[hovering sombrero]);
-	}
-	tt_convert_hatchling_into_familiar($item[hovering sombrero], $familiar[hovering sombrero]);
-	
-	//meat, MP/HP, confuse, or attack cheaply
-	if(!have_familiar($familiar[Cocoabo]))
-	{
-		retrieve_item(1, $item[cocoa egg]);
-	}
-	tt_convert_hatchling_into_familiar($item[cocoa egg], $familiar[Cocoabo]);
-	
-	//initiative and hot damage
-	if(!have_familiar($familiar[Cute Meteor]))
-	{
-		retrieve_item(1, $item[cute meteoroid]);
-	}
-	tt_convert_hatchling_into_familiar($item[cute meteoroid], $familiar[Cute Meteor]);
-	
-	//initiative for in standard runs
-	if(!have_familiar($familiar[Oily Woim]))
-	{
-		tt_acquire($item[woim]);
-	}
-	tt_convert_hatchling_into_familiar($item[woim], $familiar[Oily Woim]);
-	
-	//+1 liver while equipped allowing better rollover drinking
-	if(!have_familiar($familiar[Stooper]))
-	{
-		tt_acquire($item[Stooper]);
-	}
-	tt_convert_hatchling_into_familiar($item[Stooper], $familiar[Stooper]);
-	
-	//get an egg every ascension. if you didn't eat it then get the familiar.
-	tt_convert_hatchling_into_familiar($item[grue egg], $familiar[Grue]);
-	
-	//hatchling is a common drop
-	tt_convert_hatchling_into_familiar($item[sleeping wereturtle], $familiar[Wereturtle]);
-	
-	//nemesis quest familiars
-	tt_convert_hatchling_into_familiar($item[adorable seal larva], $familiar[Adorable Seal Larva]);		//seal clubber
-	tt_convert_hatchling_into_familiar($item[untamable turtle], $familiar[Untamed Turtle]);				//turtle tamer
-	tt_convert_hatchling_into_familiar($item[macaroni duck], $familiar[Animated Macaroni Duck]);		//pastamancer
-	tt_convert_hatchling_into_familiar($item[friendly cheez blob], $familiar[Pet Cheezling]);			//sauceror
-	tt_convert_hatchling_into_familiar($item[unusual disco ball], $familiar[Autonomous Disco Ball]);	//disco bandit
-	tt_convert_hatchling_into_familiar($item[stray chihuahua], $familiar[Mariachi Chihuahua]);			//accordion thief
-	
-	//quest items that are familiar hatchlings
-	tt_convert_hatchling_into_familiar($item[reassembled blackbird], $familiar[Reassembled Blackbird]);	//every ascension
-	tt_convert_hatchling_into_familiar($item[mosquito larva], $familiar[Mosquito]);						//every ascension
-	tt_convert_hatchling_into_familiar($item[reconstituted crow], $familiar[reconstituted crow]);		//bees hate you
-	tt_convert_hatchling_into_familiar($item[black kitten], $familiar[Black Cat]);						//bad moon
+	return false;
 }
 
 boolean tt_dailyDungeon()
@@ -263,8 +141,6 @@ boolean tt_fatLootToken(boolean override)
 		return false;
 	}
 
-	tt_acquireFamiliars();			//in case we can buy cubeling
-	
 	int tokens_needed = 73;
 	if(have_familiar($familiar[Gelatinous Cubeling]))
 	{
@@ -398,6 +274,7 @@ boolean tt_doTasks()
 	auto_interruptCheck();
 	tt_chooseFamiliar();
 	
+	if(tt_acquireFamiliars()) return true;
 	if(tt_iceHouseAMC(false)) return true;
 	if(tt_fatLootToken(false)) return true;
 	if(tt_guild(false)) return true;
@@ -418,6 +295,8 @@ boolean tt_doSingleTask(string command)
 	resetState();
 	auto_interruptCheck();	
 	tt_chooseFamiliar();
+	
+	if(tt_acquireFamiliars()) return true;
 	
 	if(command == "amc")
 	{
@@ -494,10 +373,6 @@ void main(string command)
 	tt_eatSurpriseEggs();
 	tt_consumeAll();
 	
-	if(command == "help" || command == "" || command == "0" || command == "config");
-	{
-		tt_help();
-	}
 	if(command == "auto")
 	{
 		try
@@ -510,7 +385,7 @@ void main(string command)
 			restoreAllSettings();
 		}
 	}
-	if($strings[guild, token, amc, meat] contains command)
+	else if($strings[guild, token, amc, meat] contains command)
 	{
 		try
 		{
@@ -522,4 +397,5 @@ void main(string command)
 			restoreAllSettings();
 		}
 	}
+	else tt_help();		//print instructions.
 }

--- a/RELEASE/scripts/ttpack/tt_aftercore.ash
+++ b/RELEASE/scripts/ttpack/tt_aftercore.ash
@@ -527,6 +527,25 @@ void main(string command)
 	
 	tt_settings_defaults();
 	
+	backupSetting("printStackOnAbort", true);
+	backupSetting("promptAboutCrafting", 0);
+	backupSetting("breakableHandling", 4);
+	backupSetting("dontStopForCounters", true);
+	backupSetting("choiceAdventureScript", "scripts/autoscend/auto_choice_adv.ash");
+	backupSetting("betweenBattleScript", "scripts/autoscend/auto_pre_adv.ash");
+	backupSetting("battleAction", "custom combat script");
+	backupSetting("maximizerCombinationLimit", "10000");
+	backupSetting("hpAutoRecovery", -0.05);
+	backupSetting("hpAutoRecoveryTarget", -0.05);
+	backupSetting("mpAutoRecovery", -0.05);
+	backupSetting("mpAutoRecoveryTarget", -0.05);
+	backupSetting("manaBurningTrigger", -0.05);
+	backupSetting("manaBurningThreshold", -0.05);
+	backupSetting("autoAbortThreshold", -0.05);
+	backupSetting("currentMood", "apathetic");
+	backupSetting("logPreferenceChange", "true");
+	backupSetting("logPreferenceChangeFilter", "maximizerMRUList,testudinalTeachings,auto_maximize_current");
+	
 	tt_useAstralLeftovers();
 	tt_eatSurpriseEggs();
 	tt_consumeAll();

--- a/RELEASE/scripts/ttpack/tt_aftercore.ash
+++ b/RELEASE/scripts/ttpack/tt_aftercore.ash
@@ -257,7 +257,7 @@ boolean tt_meatFarm(boolean override)
 	}
 	maximize(maximizer_string, false);
 
-	return adv1($location[The Castle in the Clouds in the Sky (Basement)], -1, "");
+	return autoAdv($location[The Castle in the Clouds in the Sky (Basement)]);
 }
 
 boolean tt_doTasks()
@@ -268,7 +268,20 @@ boolean tt_doTasks()
 	tt_chooseFamiliar();
 	if(out_of_adv()) return false;
 	
+	if(my_familiar() == $familiar[Stooper])
+	{
+		auto_log_info("Avoiding stooper stupor...", "blue");
+		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[Mosquito]);
+		use_familiar(fam);
+	}
+	if(my_inebriety() > inebriety_limit())
+	{
+		auto_log_warning("I am overdrunk", "red");
+		return false;
+	}
+	
 	if(tt_acquireFamiliars()) return true;
+	if(LX_freeCombats(true)) return true;
 	if(tt_iceHouseAMC(false)) return true;
 	if(tt_fatLootToken(false)) return true;
 	if(tt_guild(false)) return true;
@@ -283,6 +296,18 @@ boolean tt_doSingleTask(string command)
 	resetState();
 	tt_chooseFamiliar();
 	if(out_of_adv()) return false;
+	
+	if(my_familiar() == $familiar[Stooper])
+	{
+		auto_log_info("Avoiding stooper stupor...", "blue");
+		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[Mosquito]);
+		use_familiar(fam);
+	}
+	if(my_inebriety() > inebriety_limit())
+	{
+		auto_log_warning("I am overdrunk", "red");
+		return false;
+	}
 	
 	if(tt_acquireFamiliars()) return true;
 	if(command == "amc")

--- a/RELEASE/scripts/ttpack/util/tt_defaults.ash
+++ b/RELEASE/scripts/ttpack/util/tt_defaults.ash
@@ -71,6 +71,43 @@ void settings_plevel()
 	}
 }
 
+void settings_tt_aftercore()
+{
+	//configure default settings on first run for tt_aftercore.ash script
+	if(get_property("tt_aftercore_fatLootToken") == "")
+	{
+		set_property("tt_aftercore_fatLootToken", true);
+	}
+	if(get_property("tt_aftercore_iceHouseAMC") == "")
+	{
+		set_property("tt_aftercore_iceHouseAMC", true);
+	}
+	if(get_property("tt_aftercore_guildUnlock") == "")
+	{
+		set_property("tt_aftercore_guildUnlock", false);
+	}
+	if(get_property("tt_aftercore_meatFarm") == "")
+	{
+		set_property("tt_aftercore_meatFarm", false);
+	}
+	if(get_property("tt_aftercore_useAstralLeftovers") == "")
+	{
+		set_property("tt_aftercore_useAstralLeftovers", true);
+	}
+	if(get_property("tt_aftercore_buyStuff") == "")
+	{
+		set_property("tt_aftercore_buyStuff", true);
+	}
+	if(get_property("tt_aftercore_eatSurpriseEggs") == "")
+	{
+		set_property("tt_aftercore_eatSurpriseEggs", false);
+	}
+	if(get_property("tt_aftercore_consumeAll") == "")
+	{
+		set_property("tt_aftercore_consumeAll", false);
+	}
+}
+
 void tt_initialize()
 {
 	//initialize settings defaults for all associated scripts
@@ -78,4 +115,5 @@ void tt_initialize()
 	settings_tt_login();			//initialize default settings for tt_login
 	settings_greygoo();				//initialize default settings for greygoo
 	settings_plevel();				//initialize default settings for plevel
+	settings_tt_aftercore();		//initialize default settings for tt_aftercore
 }

--- a/RELEASE/scripts/ttpack/util/tt_util.ash
+++ b/RELEASE/scripts/ttpack/util/tt_util.ash
@@ -156,3 +156,13 @@ void tt_snapshot()
 
 	set_property("auto_snapshot", my_ascensions());
 }
+
+boolean out_of_adv()
+{
+	if(my_adventures() == 0)
+	{
+		print("Out of adventures", "red");
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
refactored tt_aftercore:
* refactored a bunch of code
* will now use GUI for settings
* move familiar hatching and acquisition to using autoscend functions (which I wrote as improvements over current methods)
* will now hide MRU for maximizer stringers
* added `/.github/workflows/ci.yml` file for automatic github validation of scripts